### PR TITLE
Fix build in MacOS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,12 +53,12 @@ target_link_libraries(phonon_mpv
 if(Qt5Gui_FOUND)
     add_definitions(-DWAYLAND_SUPPORT)
     include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
-    target_link_libraries(phonon_mpv Qt5Gui)
+    target_link_libraries(phonon_mpv Qt5::Gui)
 endif()
 
 if(Qt5X11Extras_FOUND)
     add_definitions(-DX11_SUPPORT)
-    target_link_libraries(phonon_mpv Qt5X11Extras)
+    target_link_libraries(phonon_mpv Qt5::X11Extras)
 endif()
 
 install(TARGETS phonon_mpv DESTINATION ${BACKEND_INSTALL_DIR})


### PR DESCRIPTION
This make compatible with MacOS (builded through Brew)

if not, fail build about missing link libraries

~~~
FAILED: src/phonon_mpv.so 
: && /usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang++ -I/Library/Java/JavaVirtualMachines/openjdk-12.0.1.jdk/Contents/Home/include -I/Library/Java/JavaVirtualMachines/openjdk-12.0.1.jdk/Contents/Home/include/darwin -std=c++0x -fno-operator-names -fno-exceptions -Wno-gnu-zero-variadic-macro-arguments -Wall -Wextra -Wcast-align -Wchar-subscripts -Wformat-security -Wno-long-long -Wpointer-arith -Wundef -Wnon-virtual-dtor -Woverloaded-virtual -Werror=return-type -Wvla -Wdate-time -fdiagnostics-color=always -DNDEBUG -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -bundle -Wl,-headerpad_max_install_names -flat_namespace -undefined dynamic_lookup -multiply_defined suppress -o src/phonon_mpv.so src/CMakeFiles/phonon_mpv.dir/phonon_mpv_autogen/mocs_compilation.cpp.o src/CMakeFiles/phonon_mpv.dir/audio/audiooutput.cpp.o src/CMakeFiles/phonon_mpv.dir/audio/audiodataoutput.cpp.o src/CMakeFiles/phonon_mpv.dir/audio/volumefadereffect.cpp.o src/CMakeFiles/phonon_mpv.dir/backend.cpp.o src/CMakeFiles/phonon_mpv.dir/effect.cpp.o src/CMakeFiles/phonon_mpv.dir/effectmanager.cpp.o src/CMakeFiles/phonon_mpv.dir/mediacontroller.cpp.o src/CMakeFiles/phonon_mpv.dir/mediaobject.cpp.o src/CMakeFiles/phonon_mpv.dir/sinknode.cpp.o src/CMakeFiles/phonon_mpv.dir/video/videowidget.cpp.o src/CMakeFiles/phonon_mpv.dir/utils/debug.cpp.o  /usr/local/lib/libphonon4qt5.4.10.2.dylib -lmpv -lQtGui /usr/local/opt/qt/lib/QtWidgets.framework/QtWidgets /usr/local/opt/qt/lib/QtGui.framework/QtGui /usr/local/opt/qt/lib/QtCore.framework/QtCore && :
ld: library not found for -lQtGui
~~~

also i tested the code in my linux. build it without problem.