### PR TITLE
Allow building with Qt 6.x/Phonon4Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,18 +20,18 @@ include(KDECompilerSettings)
 include(ECMSetupVersion)
 
 # Phonon
-find_package(Phonon4Qt5 4.10.60 NO_MODULE)
-set_package_properties(Phonon4Qt5 PROPERTIES
+find_package(Phonon4Qt${QT_MAJOR_VERSION} 4.10.60 NO_MODULE)
+set_package_properties(Phonon4Qt${QT_MAJOR_VERSION} PROPERTIES
     TYPE REQUIRED
     DESCRIPTION "Phonon core library"
     URL "https://api.kde.org/phonon/html/index.html")
 
-find_package(Phonon4Qt5Experimental 4.10.60 NO_MODULE)
-set_package_properties(Phonon4Qt5Experimental PROPERTIES
+find_package(Phonon4Qt${QT_MAJOR_VERSION}Experimental 4.10.60 NO_MODULE)
+set_package_properties(Phonon4Qt${QT_MAJOR_VERSION}Experimental PROPERTIES
     TYPE OPTIONAL
     DESCRIPTION "Phonon experimental library"
     URL "https://api.kde.org/phonon/html/index.html")
-if(Phonon4Qt5Experimental_FOUND)
+if(Phonon4Qt${QT_MAJOR_VERSION}Experimental_FOUND)
     set(PHONON_EXPERIMENTAL TRUE)
 endif()
 
@@ -39,12 +39,16 @@ endif()
 find_package(PkgConfig)
 pkg_check_modules(MPV REQUIRED mpv>=1.101.0)
 
-find_package(Qt5X11Extras)
-find_package(Qt5Gui)
+find_package(Qt${QT_MAJOR_VERSION} REQUIRED COMPONENTS Core Gui)
+if(QT_MAJOR_VERSION STREQUAL "5")
+    find_package(Qt${QT_MAJOR_VERSION} REQUIRED COMPONENTS X11Extras)
+else()
+    find_package(Qt${QT_MAJOR_VERSION} REQUIRED COMPONENTS OpenGLWidgets)
+endif()
 
 add_definitions(-DPHONON_MPV_VERSION="${PROJECT_VERSION}")
 include_directories(${MPV_INCLUDE_DIR})
-ecm_setup_version(PROJECT VARIABLE_PREFIX PHONON_VLC)
+ecm_setup_version(PROJECT VARIABLE_PREFIX PHONON_MPV)
 
 add_subdirectory(src)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,23 +22,21 @@ set(phonon_mpv_SRCS
 add_library(phonon_mpv MODULE ${phonon_mpv_SRCS})
 
 target_link_libraries(phonon_mpv
-    Phonon::phonon4qt5
+    Phonon::phonon4qt${QT_MAJOR_VERSION}
     ${MPV_LIBRARIES}
 )
 
-if(Qt5Gui_FOUND)
-    add_definitions(-DWAYLAND_SUPPORT)
+add_definitions(-DWAYLAND_SUPPORT)
+add_definitions(-DX11_SUPPORT)
+if(QT_MAJOR_VERSION STREQUAL "5")
     include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
-    target_link_libraries(phonon_mpv Qt5::Gui)
-endif()
-
-if(Qt5X11Extras_FOUND)
-    add_definitions(-DX11_SUPPORT)
-    target_link_libraries(phonon_mpv Qt5::X11Extras)
+    target_link_libraries(phonon_mpv Qt::Gui Qt::X11Extras)
+else()
+    target_link_libraries(phonon_mpv Qt::Core Qt::Gui Qt::OpenGLWidgets)
 endif()
 
 if(PHONON_EXPERIMENTAL)
-    target_link_libraries(phonon_mpv Phonon::phonon4qt5experimental)
+    target_link_libraries(phonon_mpv Phonon::phonon4qt${QT_MAJOR_VERSION}experimental)
 endif()
 
 install(TARGETS phonon_mpv DESTINATION ${PHONON_BACKEND_DIR})

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -26,7 +26,6 @@
 #include <QDir>
 #include <QResizeEvent>
 #include <QIcon>
-#include <QLatin1Literal>
 #include <QMessageBox>
 #include <QtPlugin>
 #include <QSettings>

--- a/src/mediacontroller.cpp
+++ b/src/mediacontroller.cpp
@@ -276,7 +276,7 @@ void MediaController::refreshAudioChannels() {
             if(i == currentChannelId) {
                 const QList<AudioChannelDescription> list{GlobalAudioChannels::instance()->listFor(this)};
                 foreach(const AudioChannelDescription &descriptor, list) {
-                    if(descriptor.name() == id)
+                    if(descriptor.name() == QString::number(id))
                         m_currentAudioChannel = descriptor;
                 }
             }

--- a/src/mediaobject.cpp
+++ b/src/mediaobject.cpp
@@ -26,6 +26,11 @@
 #include <QStringBuilder>
 #include <QUrl>
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QLatin1StringView>
+#define QLatin1Literal QLatin1StringView
+#endif
+
 #define MPV_ENABLE_DEPRECATED 0
 #include <mpv/client.h>
 

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -21,8 +21,8 @@
 #include "debug.h"
 #include "debug_p.h"
 
-#include <QtCore/QMutex>
-#include <QtCore/QObject>
+#include <QRecursiveMutex>
+#include <QObject>
 #include <QApplication>
 
 #ifdef Q_OS_UNIX
@@ -36,7 +36,7 @@
 
 #define DEBUG_INDENT_OBJECTNAME QLatin1String("Debug_Indent_object")
 
-QMutex Debug::mutex( QMutex::Recursive );
+QRecursiveMutex Debug::mutex;
 
 using namespace Debug;
 
@@ -218,5 +218,5 @@ Block::~Block()
 void Debug::stamp()
 {
     static int n = 0;
-    debug() << "| Stamp: " << ++n << endl;
+    debug() << "| Stamp: " << ++n << Qt::endl;
 }

--- a/src/utils/debug.h
+++ b/src/utils/debug.h
@@ -25,10 +25,10 @@
 #undef QT_NO_DEBUG_OUTPUT
 #undef KDE_NO_DEBUG_OUTPUT
 
-#include <QtCore/QDebug>
-#include <QtCore/QMutex>
+#include <QDebug>
+#include <QRecursiveMutex>
 
-# include <QtCore/QElapsedTimer>
+#include <QElapsedTimer>
 
 /**
  * @namespace Debug
@@ -61,7 +61,7 @@
  */
 namespace Debug
 {
-    extern QMutex mutex;
+    extern QRecursiveMutex mutex;
 
     enum DebugLevel {
         DEBUG_INFO  = 0,

--- a/src/utils/debug_p.h
+++ b/src/utils/debug_p.h
@@ -22,6 +22,7 @@
 #include "debug.h"
 
 #include <QtCore/QString>
+#include <QIODevice>
 
 class IndentPrivate
     : public QObject


### PR DESCRIPTION
This allows building phonon-mpv with Phonon4Qt6 and Qt 6.x (tried 6.6.0). It doesn't break building with 5.x.