### PR TITLE
Fix possible crash when a file is done playing

### DIFF
--- a/src/mediaobject.cpp
+++ b/src/mediaobject.cpp
@@ -25,6 +25,7 @@
 #include <QDir>
 #include <QStringBuilder>
 #include <QUrl>
+#include <QList>
 
 #define MPV_ENABLE_DEPRECATED 0
 #include <mpv/client.h>
@@ -38,6 +39,8 @@
 static const int ABOUT_TO_FINISH_TIME = 2000;
 
 using namespace Phonon::MPV;
+
+static QList<void*> recentlyDestroyed;
 
 MediaObject::MediaObject(QObject* parent)
     : QObject(parent)
@@ -72,9 +75,14 @@ MediaObject::MediaObject(QObject* parent)
 }
 
 MediaObject::~MediaObject() {
+    recentlyDestroyed.append(this);
 }
 
 void MediaObject::event_cb(void *opaque) {
+    if(recentlyDestroyed.contains(opaque)) {
+        recentlyDestroyed.removeAll(opaque);
+        return;
+    }
     MediaObject* that = reinterpret_cast<MediaObject*>(opaque);
     QMetaObject::invokeMethod(
                     that,


### PR DESCRIPTION
There's a race condition in which MediaObject::event_cb can be called (as a result of an event caught by mpv_set_wakeup_callback) after the object pointed to by the opaque pointer has already been destroyed.

This causes phonon-mpv to crash when a file has finished playing.

This fix isn't very nice (essentially it just keeps a list of recently destroyed MediaObjects and avoids calling invokeMethod on them), but it works.

At least for me, the crash is 100% reproducible (simply open phononsettings or phononsettings6, play a test sound, and watch it crash as soon as the test sound is done playing -- Qt 5.15.11 and 6.6.0 on a Ryzen 9 5950X) without the patch.