### PR TITLE
Fix video rendering on screens with scale factor > 1.0

### DIFF
--- a/src/video/videowidget.cpp
+++ b/src/video/videowidget.cpp
@@ -98,7 +98,10 @@ void VideoWidget::initializeGL() {
 }
 
 void VideoWidget::paintGL() {
-    mpv_opengl_fbo mpfbo{static_cast<int>(defaultFramebufferObject()), width(), height(), 0};
+    qreal raito = window()->devicePixelRatio();
+    int widthPx = width() * raito;
+    int heightPx = height() * raito;
+    mpv_opengl_fbo mpfbo{static_cast<int>(defaultFramebufferObject()), widthPx, heightPx, 0};
     auto flip_y{1};
     mpv_render_param params[] = {
         {MPV_RENDER_PARAM_OPENGL_FBO, &mpfbo},


### PR DESCRIPTION
As per https://doc.qt.io/qt-6/highdpi.html#drawing

> However, when using lower level drawing APIs, for example OpenGL, the application needs to take the device pixel ratio of the display into account. This is available both per window, as [`QWindow::devicePixelRatio()`](https://doc.qt.io/qt-6/qwindow.html#devicePixelRatio)

the application should apply HiDPI scaling itself when rendering with OpenGL.

Here's a before/after comparison in Gwenview with 2x global scale

|Before|After|
|:----:|:---:|
|![image](https://github.com/OpenProgger/phonon-mpv/assets/13914967/0fa46c79-51ec-43fa-bab0-b17126a0587d)|![image](https://github.com/OpenProgger/phonon-mpv/assets/13914967/0b8cff43-40ca-4942-b9c7-2bcb502f338e)|