### PR TITLE
Enable hardware video decoding

### DIFF
--- a/src/video/videowidget.cpp
+++ b/src/video/videowidget.cpp
@@ -93,6 +93,8 @@ void VideoWidget::initializeGL() {
     mpv_render_context_set_update_callback(mpv_gl, onUpdate, reinterpret_cast<void *>(this));
     if((err = mpv_set_property_string(m_player, "vo", "libmpv")))
         warning() << "failed to enable video rendering: " << mpv_error_string(err);
+    if ((err = mpv_set_property_string(m_player, "hwdec", "auto")))
+        warning() << "failed to enable hardware video decoding: " << mpv_error_string(err);
     m_mediaObject->stop();
     m_mediaObject->loadMedia(QByteArray());
 }


### PR DESCRIPTION
Set mpv porperty `hwdec=auto` should enable hardware video decoding on most devices, and I can confirm it works in Gwenview:

![image](https://github.com/OpenProgger/phonon-mpv/assets/13914967/b6ac36bc-3afc-4caf-aebb-813536edf178)

Is it suitable to enable hwdec by default?

Or should we have an option (in a configuration file) to control hwdec behavior? Like in https://github.com/KDE/purpose/blob/c6cc4fd35f1d89234d06260e2746e98b05583d71/src/alternativesmodel.cpp#L309-L311 , only a purposerc file but no configuration UI.